### PR TITLE
Add code coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,2 @@
+output-type: lcov
+output-file: ./lcov.info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,3 +35,21 @@ jobs:
       run: |
         cargo check
         cargo test --all --verbose
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+
+    - name: rust-grcov
+      uses: actions-rs/grcov@v0.1
+
+    - name: Codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+      with:
+        # Repository upload token - get it from codecov.io. Required only for private repositories
+        # token: # optional
+        # Specify whether the Codecov output should be verbose
+        verbose: true
+        fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "**" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
 
     - name: Update local toolchain
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["no-std", "cayenne", "lpp", "lpwan", "lorawan"]
 license = "MIT"
 readme = "README.md"
 exclude = ["tests/*"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 [![build](https://github.com/Octoate/CayenneLPP-rs/actions/workflows/build.yml/badge.svg)](https://github.com/octoate/CayenneLPP-rs/actions)
+[![codecov](https://codecov.io/github/Octoate/CayenneLPP-rs/graph/badge.svg?token=F58DRE5E0D)](https://codecov.io/github/Octoate/CayenneLPP-rs)
 ![crates.io](https://img.shields.io/crates/v/cayenne_lpp)
 ![docs.rs](https://img.shields.io/docsrs/cayenne_lpp)
 ![license](https://img.shields.io/crates/l/cayenne_lpp.svg)


### PR DESCRIPTION
The code coverage of the tests should be visible in the README as a badge. The coverage itself shall run in the GitHub action and shall be uploaded to Codecov.