### PR TITLE
Add error enum to return methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["no-std", "cayenne", "lpp", "lpwan", "lorawan"]
 license = "MIT"
 readme = "README.md"
 exclude = ["tests/*"]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ fn main() {
 
 ## Future development
 
-The API in its current state should be pretty stable to use, but it might be extended for a more detailed error response
-when adding new values to the data structure in the future.  
+The API in its current state should be pretty stable to use. Currently it only supports ```no_std```, but it would be
+possible to support an easier to use API for ```std``` as well.  
 However, if you have any remarks or want to add some functionality feel free to start a discussion or send a PR, but do
 not forget to add unit tests and / or integration tests, if you want that it gets merged into the repo.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,13 @@ pub struct CayenneLPP<'a> {
     index: usize
 }
 
+/// Defines all the errors that can occur in this crate.
+#[derive(Debug, PartialEq, Clone)]
+pub enum Error {
+    /// The buffer is too small to add the value
+    NotEnoughMemory
+}
+
 impl<'a> CayenneLPP<'a> {
 
     /// Creates a new buffer for the Cayenne LPP. Since the library works without a memory allocator, it is necessary
@@ -125,9 +132,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for a digital input to the Cayenne LPP data structure.
-    pub fn add_digital_input(&mut self, channel: u8, value: u8) -> Result<(), ()> {
+    pub fn add_digital_input(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_DIGITAL_INPUT_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -139,9 +146,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for a digital output to the Cayenne LPP data structure.
-    pub fn add_digital_output(&mut self, channel: u8, value: u8) -> Result<(), ()> {
+    pub fn add_digital_output(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_DIGITAL_OUTPUT_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -153,9 +160,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for an analog input to the Cayenne LPP data structure.
-    pub fn add_analog_input(&mut self, channel: u8, value: f32) -> Result<(), ()> {
+    pub fn add_analog_input(&mut self, channel: u8, value: f32) -> Result<(), Error> {
         if self.index + LPP_ANALOG_INPUT_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         let analog_input: i16 = (value * 100.0) as i16;
@@ -171,9 +178,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for an analog output to the Cayenne LPP data structure.
-    pub fn add_analog_output(&mut self, channel: u8, value: f32) -> Result<(), ()> {
+    pub fn add_analog_output(&mut self, channel: u8, value: f32) -> Result<(), Error> {
         if self.index + LPP_ANALOG_OUTPUT_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         let analog_output: i16 = (value * 100.0) as i16;
@@ -189,9 +196,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for luminosity to the Cayenne LPP data structure. The value should be provided in lux.
-    pub fn add_luminosity(&mut self, channel: u8, lux: u16) -> Result<(), ()> {
+    pub fn add_luminosity(&mut self, channel: u8, lux: u16) -> Result<(), Error> {
         if self.index + LPP_LUMINOSITY_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -204,9 +211,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for a presence sensor to the Cayenne LPP data structure.
-    pub fn add_presence(&mut self, channel: u8, value: u8) -> Result<(), ()> {
+    pub fn add_presence(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_PRESENCE_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -218,9 +225,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for temperature to the Cayenne LPP data structure.
-    pub fn add_temperature(&mut self, channel: u8, celsius: f32) -> Result<(), ()> {
+    pub fn add_temperature(&mut self, channel: u8, celsius: f32) -> Result<(), Error> {
         if self.index + LPP_TEMPERATURE_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         let temperature: i16 = (celsius * 10.0) as i16;
@@ -236,9 +243,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for relative humidity to the Cayenne LPP data structure.
-    pub fn add_relative_humidity(&mut self, channel: u8, relative_humidity: f32) -> Result<(), ()> {
+    pub fn add_relative_humidity(&mut self, channel: u8, relative_humidity: f32) -> Result<(), Error> {
         if self.index + LPP_RELATIVE_HUMIDITY_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -250,9 +257,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload of an accelerometer to the Cayenne LPP data structure.
-    pub fn add_accelerometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), ()> {
+    pub fn add_accelerometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), Error> {
         if self.index + LPP_ACCELEROMETER_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         // prepare axis values
@@ -274,9 +281,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for barometric pressure to the Cayenne LPP data structure.
-    pub fn add_barometric_pressure(&mut self, channel: u8, hpa: f32) -> Result<(), ()> {
+    pub fn add_barometric_pressure(&mut self, channel: u8, hpa: f32) -> Result<(), Error> {
         if self.index + LPP_BAROMETRIC_PRESSURE_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         let pressure = (hpa * 10.0) as u16;
@@ -291,9 +298,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for a gyrometer to the Cayenne LPP data structure.
-    pub fn add_gyrometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), ()> {
+    pub fn add_gyrometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), Error> {
         if self.index + LPP_GYROMETER_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         // prepare axis values
@@ -315,9 +322,9 @@ impl<'a> CayenneLPP<'a> {
     }
 
     /// Adds the payload for GPS to the Cayenne LPP data structure.
-    pub fn add_gps(&mut self, channel: u8, latitude: f32, longitude: f32, meters: f32) -> Result<(), ()> {
+    pub fn add_gps(&mut self, channel: u8, latitude: f32, longitude: f32, meters: f32) -> Result<(), Error> {
         if self.index + LPP_GPS_SIZE > self.buffer.len() {
-            return Err(());
+            return Err(Error::NotEnoughMemory);
         }
 
         // prepare GPS values (3 bytes each)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub struct CayenneLPP<'a> {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     /// The buffer is too small to add the value
-    NotEnoughMemory
+    InsufficientMemory
 }
 
 impl<'a> CayenneLPP<'a> {
@@ -134,7 +134,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for a digital input to the Cayenne LPP data structure.
     pub fn add_digital_input(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_DIGITAL_INPUT_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -148,7 +148,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for a digital output to the Cayenne LPP data structure.
     pub fn add_digital_output(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_DIGITAL_OUTPUT_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -162,7 +162,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for an analog input to the Cayenne LPP data structure.
     pub fn add_analog_input(&mut self, channel: u8, value: f32) -> Result<(), Error> {
         if self.index + LPP_ANALOG_INPUT_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         let analog_input: i16 = (value * 100.0) as i16;
@@ -180,7 +180,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for an analog output to the Cayenne LPP data structure.
     pub fn add_analog_output(&mut self, channel: u8, value: f32) -> Result<(), Error> {
         if self.index + LPP_ANALOG_OUTPUT_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         let analog_output: i16 = (value * 100.0) as i16;
@@ -198,7 +198,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for luminosity to the Cayenne LPP data structure. The value should be provided in lux.
     pub fn add_luminosity(&mut self, channel: u8, lux: u16) -> Result<(), Error> {
         if self.index + LPP_LUMINOSITY_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -213,7 +213,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for a presence sensor to the Cayenne LPP data structure.
     pub fn add_presence(&mut self, channel: u8, value: u8) -> Result<(), Error> {
         if self.index + LPP_PRESENCE_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -227,7 +227,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for temperature to the Cayenne LPP data structure.
     pub fn add_temperature(&mut self, channel: u8, celsius: f32) -> Result<(), Error> {
         if self.index + LPP_TEMPERATURE_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         let temperature: i16 = (celsius * 10.0) as i16;
@@ -245,7 +245,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for relative humidity to the Cayenne LPP data structure.
     pub fn add_relative_humidity(&mut self, channel: u8, relative_humidity: f32) -> Result<(), Error> {
         if self.index + LPP_RELATIVE_HUMIDITY_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         self.buffer[self.index] = channel;
@@ -259,7 +259,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload of an accelerometer to the Cayenne LPP data structure.
     pub fn add_accelerometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), Error> {
         if self.index + LPP_ACCELEROMETER_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         // prepare axis values
@@ -283,7 +283,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for barometric pressure to the Cayenne LPP data structure.
     pub fn add_barometric_pressure(&mut self, channel: u8, hpa: f32) -> Result<(), Error> {
         if self.index + LPP_BAROMETRIC_PRESSURE_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         let pressure = (hpa * 10.0) as u16;
@@ -300,7 +300,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for a gyrometer to the Cayenne LPP data structure.
     pub fn add_gyrometer(&mut self, channel: u8, x: f32, y: f32, z: f32) -> Result<(), Error> {
         if self.index + LPP_GYROMETER_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         // prepare axis values
@@ -324,7 +324,7 @@ impl<'a> CayenneLPP<'a> {
     /// Adds the payload for GPS to the Cayenne LPP data structure.
     pub fn add_gps(&mut self, channel: u8, latitude: f32, longitude: f32, meters: f32) -> Result<(), Error> {
         if self.index + LPP_GPS_SIZE > self.buffer.len() {
-            return Err(Error::NotEnoughMemory);
+            return Err(Error::InsufficientMemory);
         }
 
         // prepare GPS values (3 bytes each)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ fn add_digital_input_overflow() {
     lpp.add_digital_input(3, 0xAA).unwrap();
     let result = lpp.add_digital_input(5, 0x55);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn add_analog_input_overflow() {
     lpp.add_analog_input(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn add_analog_output_overflow() {
     lpp.add_analog_input(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn add_digital_output_overflow() {
     lpp.add_digital_output(3, 0xAA).unwrap();
     let result = lpp.add_digital_output(5, 0x55);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn add_luminosity_overflow() {
     lpp.add_luminosity(2, 0x55AA).unwrap();
     let result = lpp.add_luminosity(5, 0xAA55);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn add_presence_overflow() {
     lpp.add_presence(2, 0x55).unwrap();
     let result = lpp.add_presence(5, 0xAA);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn add_temperature_overflow() {
     lpp.add_temperature(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn add_relative_humidity_overflow() {
     lpp.add_relative_humidity(3, 27.2).unwrap();
     let result = lpp.add_relative_humidity(5, 25.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn ass_accelerometer_overflow() {
     lpp.add_accelerometer(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_accelerometer(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn add_barometric_pressure_overflow() {
     lpp.add_barometric_pressure(3, 27.2).unwrap();
     let result = lpp.add_barometric_pressure(5, 25.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn add_gyrometer_overflow() {
     lpp.add_gyrometer(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_gyrometer(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }
 
 #[test]
@@ -320,5 +320,5 @@ fn add_gps_overflow() {
     lpp.add_gps(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_gps(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(()), result);
+    assert_eq!(Err(Error::NotEnoughMemory), result);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ fn add_digital_input_overflow() {
     lpp.add_digital_input(3, 0xAA).unwrap();
     let result = lpp.add_digital_input(5, 0x55);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn add_analog_input_overflow() {
     lpp.add_analog_input(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn add_analog_output_overflow() {
     lpp.add_analog_input(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn add_digital_output_overflow() {
     lpp.add_digital_output(3, 0xAA).unwrap();
     let result = lpp.add_digital_output(5, 0x55);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn add_luminosity_overflow() {
     lpp.add_luminosity(2, 0x55AA).unwrap();
     let result = lpp.add_luminosity(5, 0xAA55);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn add_presence_overflow() {
     lpp.add_presence(2, 0x55).unwrap();
     let result = lpp.add_presence(5, 0xAA);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn add_temperature_overflow() {
     lpp.add_temperature(3, 27.2).unwrap();
     let result = lpp.add_temperature(5, 25.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn add_relative_humidity_overflow() {
     lpp.add_relative_humidity(3, 27.2).unwrap();
     let result = lpp.add_relative_humidity(5, 25.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn ass_accelerometer_overflow() {
     lpp.add_accelerometer(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_accelerometer(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn add_barometric_pressure_overflow() {
     lpp.add_barometric_pressure(3, 27.2).unwrap();
     let result = lpp.add_barometric_pressure(5, 25.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn add_gyrometer_overflow() {
     lpp.add_gyrometer(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_gyrometer(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }
 
 #[test]
@@ -320,5 +320,5 @@ fn add_gps_overflow() {
     lpp.add_gps(3, 27.2, 34.2, 56.1).unwrap();
     let result = lpp.add_gps(5, 25.5, 98.1, 23.5);
 
-    assert_eq!(Err(Error::NotEnoughMemory), result);
+    assert_eq!(Err(Error::InsufficientMemory), result);
 }


### PR DESCRIPTION
The add functions in the API shall return an error code if the size of the byte buffer is not sufficient.