### PR TITLE
Make main iterator failable and add an infailable convenience iterator

### DIFF
--- a/src/cayenne_lpp_into_iterator.rs
+++ b/src/cayenne_lpp_into_iterator.rs
@@ -1,9 +1,16 @@
 use crate::CayenneLPP;
 use crate::cayenne_lpp_scalar::{CayenneLPPScalar, CayenneLPPValue};
 use crate::constants::*;
+use crate::error::Error;
 
 /// Iterator over the CayenneLPP Scalars parsed from a data structure
-pub struct CayenneLPPIntoIterator<'a> {
+/// This version will return Option<Result<CayenneLPPScalar>>.  Some(Err(...))
+/// will be returned when there was an error unpacking a CayenneLPP scalar.
+/// the most likely causes of this error would be unhandled type codes,
+/// out-of-bounds results, and stray bytes at the end of the bytestream.
+/// Any of these could indicate corrupt data or, perhaps, that the provided
+/// byte stream isn't actually in CayenneLPP format.
+pub struct CayenneLPPIntoFailableIterator<'a> {
     /// The CayenneLPP instance that this iterator is over
     pub(crate) lpp: CayenneLPP<'a>,
 
@@ -11,7 +18,7 @@ pub struct CayenneLPPIntoIterator<'a> {
     pub(crate) index: usize
 }
 
-impl<'a> CayenneLPPIntoIterator<'a> {
+impl<'a> CayenneLPPIntoFailableIterator<'a> {
     // All of these functions are unsafe in the sense that they
     // rely on the size bounds being already checked.
     fn get_u32(&mut self) -> u32 {
@@ -77,13 +84,14 @@ impl<'a> CayenneLPPIntoIterator<'a> {
     }
 }
 
-impl<'a> Iterator for CayenneLPPIntoIterator<'a> {
-    type Item = CayenneLPPScalar;
+impl<'a> Iterator for CayenneLPPIntoFailableIterator<'a> {
+    type Item = Result<CayenneLPPScalar, Error>;
 
-    fn next(&mut self) -> Option<CayenneLPPScalar> {
+    fn next(&mut self) -> Option<Result<CayenneLPPScalar, Error>> {
         let buffer = &self.lpp.buffer;
 
-        // Identify the case where we've gotten to the end of the buffer
+        // Identify the case where we've gotten to the end of the
+        // buffer cleanly, and we're done processing bytes.
         if buffer.len() < self.index + 1 {
             return None
         }
@@ -93,312 +101,360 @@ impl<'a> Iterator for CayenneLPPIntoIterator<'a> {
         // when next is called.
         let channel = buffer[self.index];
         self.index += 1;
+
         let type_code = buffer[self.index];
         self.index += 1;
 
         match type_code {
             LPP_DIGITAL_INPUT => {
                 let remaining_length = LPP_DIGITAL_INPUT_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::DigitalInput(self.get_u8()) }
-                )
+                ))
             },
 
             LPP_DIGITAL_OUTPUT => {
                 let remaining_length = LPP_DIGITAL_OUTPUT_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::DigitalOutput(self.get_u8()) }
-                )
+                ))
             },
 
             LPP_ANALOG_INPUT => {
                 let remaining_length = LPP_ANALOG_INPUT_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let value = self.get_i16() as f32 / 100.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::AnalogInput(value)
-                })
+                }))
             },
 
             LPP_ANALOG_OUTPUT => {
                 let remaining_length = LPP_ANALOG_OUTPUT_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let value = self.get_i16() as f32 / 100.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::AnalogOutput(value)
-                })
+                }))
             },
 
             LPP_GENERIC_SENSOR => {
                 let remaining_length = LPP_GENERIC_SENSOR_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::GenericSensor(self.get_u32())
-                })
+                }))
             },
 
             LPP_LUMINOSITY => {
                 let remaining_length = LPP_LUMINOSITY_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Luminosity(self.get_u16())
-                })
+                }))
             },
 
             LPP_PRESENCE => {
                 let remaining_length = LPP_PERCENTAGE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Presence(self.get_u8()) }
-                )
+                ))
             },
 
             LPP_TEMPERATURE => {
                 let remaining_length = LPP_TEMPERATURE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let value = self.get_i16() as f32 / 10.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Temperature(value)
-                })
+                }))
 
             },
 
             LPP_RELATIVE_HUMIDITY => {
                 let remaining_length = LPP_RELATIVE_HUMIDITY_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let value = self.get_u8() as f32 / 2.0;
 
-                Some(CayenneLPPScalar {
+                // Relative humidity cannot be more than 100%, but
+                // I don't neceesssarly cause an error if a sensor
+                // is a little bit off, so we're not going to bounds
+                // check here.  The natural value of the type bounds
+                // it between 0 - 128%.
+
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::RelativeHumidity(value)
-                })
+                }))
             },
 
             LPP_ACCELEROMETER => {
                 let remaining_length = LPP_ACCELEROMETER_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let vx = self.get_i16() as f32 / 1000.0;
                 let vy = self.get_i16() as f32 / 1000.0;
                 let vz = self.get_i16() as f32 / 1000.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Accelerometer(
                         vx, vy, vz
                     )
-                })
+                }))
             },
 
             LPP_BAROMETRIC_PRESSURE => {
                 let remaining_length = LPP_BAROMETRIC_PRESSURE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let pressure = self.get_u16() as f32 / 10.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::BarometricPressure(pressure)
-                })
+                }))
             },
 
             LPP_VOLTAGE => {
                 let remaining_length = LPP_VOLTAGE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let voltage = self.get_u16() as f32 / 100.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Voltage(voltage)
-                })
+                }))
             },
 
             LPP_CURRENT => {
                 let remaining_length = LPP_CURRENT_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let amperage = self.get_u16() as f32 / 1000.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Current(amperage)
-                })
+                }))
             },
 
             LPP_FREQUENCY => {
                 let remaining_length = LPP_FREQUENCY_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Frequency(self.get_u32())
-                })
+                }))
             },
 
             LPP_PERCENTAGE => {
                 let remaining_length = LPP_PERCENTAGE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Percentage(self.get_u8()) }
-                )
+                ))
             },
 
             LPP_ALTITUDE => {
                 let remaining_length = LPP_ALTITUDE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(
+                Some(Ok(
                     CayenneLPPScalar {
                         channel,
                         value: CayenneLPPValue::Altitude(self.get_i16())
                     }
-                )
+                ))
             },
 
             LPP_POWER => {
                 let remaining_length = LPP_POWER_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Power(self.get_u16())
-                })
+                }))
             },
 
             LPP_DISTANCE => {
                 let remaining_length = LPP_DISTANCE_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Distance(self.get_u32())
-                })
+                }))
             },
 
             LPP_ENERGY => {
                 let remaining_length = LPP_ENERGY_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Energy(self.get_u32())
-                })
+                }))
             },
 
             LPP_DIRECTION => {
                 let remaining_length = LPP_DIRECTION_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                // I'm specifically not bounds checking direction because
+                // I could see it being equally valid to use +/- to refer
+                // to left or right of north, or to have directions larger
+                // than 360 to indicate more than one turn.
+
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Direction(self.get_u16())
-                })
+                }))
             },
 
             LPP_UNIXTIME => {
                 let remaining_length = LPP_UNIXTIME_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::UnixTime(self.get_u32())
-                })
+                }))
             },
 
             LPP_GYROMETER => {
                 let remaining_length = LPP_GYROMETER_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let vx = self.get_u16() as f32 / 100.0;
                 let vy = self.get_u16() as f32 / 100.0;
                 let vz = self.get_u16() as f32 / 100.0;
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Gyrometer(
                         vx, vy, vz
                     )
-                })
+                }))
             },
 
             LPP_GPS => {
                 let remaining_length = LPP_GPS_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let lat = self.get_i24() as f32 / 10_000.0;
                 let lon = self.get_i24() as f32 / 10_000.0;
                 let alt = self.get_i24() as f32 / 100.0;
 
-                Some(CayenneLPPScalar {
+                // Do some basic sanity bounds checking.
+                // The maximum latitude is +/- 90 degrees N/S
+                if lat > 90.0 || lat < -90.0 {
+                    return Some(Err(Error::OutOfRange));
+                }
+
+                // Same for longitude, but this time it's +/- 180.
+                if lon > 180.0 || lon < -180.0 {
+                    return Some(Err(Error::OutOfRange));
+                }
+
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::GPS(
                         lat,
                         lon,
                         alt)
-                })
+                }))
             },
 
             LPP_SWITCH => {
                 let remaining_length = LPP_SWITCH_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Switch(self.get_u8() != 0)
-                })
+                }))
             },
 
             LPP_CONCENTRATION => {
                 let remaining_length = LPP_CONCENTRATION_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Concentration(self.get_u16())
-                })
+                }))
 
             },
 
             LPP_COLOR => {
                 let remaining_length = LPP_COLOR_SIZE - 2;
-                if buffer.len() < self.index + remaining_length { return None }
+                if buffer.len() < self.index + remaining_length { return Some(Err(Error::BufferUnderrun)) }
 
                 let r = self.get_u8();
                 let g = self.get_u8();
                 let b = self.get_u8();
 
-                Some(CayenneLPPScalar {
+                Some(Ok(CayenneLPPScalar {
                     channel,
                     value: CayenneLPPValue::Color(r, g, b)
-                })
+                }))
             },
 
-            _ => None
+            _ => Some(Err(Error::UnhandledType(type_code)))
         }
     }
+}
+
+pub struct CayenneLPPIterator<'a> {
+    pub(crate) failable_iterator: CayenneLPPIntoFailableIterator<'a>
+}
+
+impl<'a> CayenneLPP<'a> {
+    /// Create an infallable iterator.  This iterator flattens
+    /// the result from a Option<Result<CayenneLPPScalar>> into
+    /// just an Option.  This is useful if you want to just stop
+    /// processing the byte stream when the first error is encountered.
+    pub fn into_infailable_iter(self) -> CayenneLPPIterator<'a> {
+        CayenneLPPIterator { failable_iterator: self.into_iter() }
+    }
+}
+
+impl<'a> Iterator for CayenneLPPIterator<'a> {
+    type Item = CayenneLPPScalar;
+
+    fn next(&mut self) -> Option<CayenneLPPScalar> {
+        match self.failable_iterator.next() {
+            Some(Ok(s)) => Some(s),
+            _ => None,
+        }
+    }     
 }

--- a/src/cayenne_lpp_into_iterator.rs
+++ b/src/cayenne_lpp_into_iterator.rs
@@ -440,7 +440,7 @@ pub struct CayenneLPPIterator<'a> {
 
 impl<'a> CayenneLPP<'a> {
     /// Create an infallable iterator.  This iterator flattens
-    /// the result from a Option<Result<CayenneLPPScalar>> into
+    /// the result from a `Option<Result<CayenneLPPScalar>>` into
     /// just an Option.  This is useful if you want to just stop
     /// processing the byte stream when the first error is encountered.
     pub fn into_infailable_iter(self) -> CayenneLPPIterator<'a> {

--- a/src/cayenne_lpp_scalar.rs
+++ b/src/cayenne_lpp_scalar.rs
@@ -1,5 +1,5 @@
 /// Enumeration of the CayenneLPP value that are supported by this library
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum CayenneLPPValue {
     /// Data type of a digital input
     DigitalInput(u8),
@@ -77,6 +77,106 @@ pub enum CayenneLPPValue {
 
     /// Data type of a switch value
     Switch(bool),
+}
+
+impl core::fmt::Debug for CayenneLPPValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DigitalInput(arg0) => {
+                f.debug_tuple("DigitalInput").field(arg0).finish()
+            },
+            Self::DigitalOutput(arg0) => {
+                f.debug_tuple("DigitalOutput").field(arg0).finish()
+            },
+            Self::AnalogInput(arg0) => {
+                f.debug_tuple("AnalogInput").field(arg0).finish()
+            },
+            Self::AnalogOutput(arg0) => {
+                f.debug_tuple("AnalogOutput").field(arg0).finish()
+            },
+            Self::GenericSensor(arg0) => {
+                f.debug_tuple("GenericSensor").field(arg0).finish()
+            },
+            Self::Luminosity(arg0) => {
+                f.debug_tuple("Luminosity (lux) ").field(arg0).finish()
+            },
+            Self::Presence(arg0) => {
+                f.debug_tuple("Presence").field(arg0).finish()
+            },
+            Self::Temperature(arg0) => {
+                f.debug_tuple("Degrees C").field(arg0).finish()
+            },
+            Self::RelativeHumidity(arg0) => {
+                f.debug_tuple("RelativeHumidity").field(arg0).finish()
+            },
+            Self::Accelerometer(arg0, arg1, arg2) => {
+                f.debug_struct("Accelerometer")
+                    .field("X", arg0)
+                    .field("Y", arg1)
+                    .field("Z", arg2)
+                    .finish()
+            },
+            Self::BarometricPressure(arg0) => {
+                f.debug_tuple("BarometricPressure (hPa) ").field(arg0).finish()
+            },
+            Self::Voltage(arg0) => {
+                f.debug_tuple("Voltage").field(arg0).finish()
+            },
+            Self::Current(arg0) => {
+                f.debug_tuple("Current (A) ").field(arg0).finish()
+            },
+            Self::Frequency(arg0) => {
+                f.debug_tuple("Frequency (hz) ").field(arg0).finish()
+            },
+            Self::Percentage(arg0) => {
+                f.debug_tuple("Percentage").field(arg0).finish()
+            },
+            Self::Altitude(arg0) => {
+                f.debug_tuple("Altitude (M) ").field(arg0).finish()
+            },
+            Self::Concentration(arg0) => {
+                f.debug_tuple("Concentration (ppm) ").field(arg0).finish()
+            },
+            Self::Power(arg0) => {
+                f.debug_tuple("Power (W) ").field(arg0).finish()
+            },
+            Self::Distance(arg0) => {
+                f.debug_tuple("Distance (M) ").field(arg0).finish()
+            },
+            Self::Energy(arg0) => {
+                f.debug_tuple("Energy (Wh) ").field(arg0).finish()
+            },
+            Self::Direction(arg0) => {
+                f.debug_tuple("Direction (deg) ").field(arg0).finish()
+            },
+            Self::UnixTime(arg0) => {
+                f.debug_tuple("UnixTime").field(arg0).finish()
+            },
+            Self::Gyrometer(arg0, arg1, arg2) => {
+                f.debug_struct("Gyrometer")
+                    .field("X", arg0)
+                    .field("Y", arg1)
+                    .field("Z", arg2)
+                    .finish()
+            },
+            Self::Color(arg0, arg1, arg2) => {
+                f.debug_struct("Color")
+                    .field("R", arg0)
+                    .field("G", arg1)
+                    .field("B", arg2)
+                    .finish()
+            },
+            Self::GPS(arg0, arg1, arg2) => {
+                f.debug_struct("GPS location")
+                    .field("Lat", arg0)
+                    .field("Lon", arg1)
+                    .field("Alt", arg2)
+                    .finish()
+            },
+            Self::Switch(arg0) => {f.debug_tuple("Switch").field(arg0).finish()
+            },
+        }
+    }
 }
 
 /// Single value parsed from a CayenneLPP data structure,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,4 +5,11 @@ pub enum Error {
     InsufficientMemory,
     /// The provided value is not representable by CayenneLPP
     OutOfRange,
+    /// The provided byte buffer didn't contain enough bytes
+    /// to unpack the next scalar
+    BufferUnderrun,
+    /// The provided type code is either invalid or
+    /// not handled by this library
+    UnhandledType(u8),
+    
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -655,6 +655,17 @@ fn add_gps_overflow() {
 }
 
 #[test]
+fn add_gps_bounds() {
+    let mut buffer: [u8; LPP_GPS_SIZE + 2] = [0; LPP_GPS_SIZE + 2];
+    let mut lpp = CayenneLPP::new(&mut buffer);
+
+    assert_eq!(lpp.add_gps(3,  100.0,   34.2, 56.1), Err(Error::OutOfRange));
+    assert_eq!(lpp.add_gps(3, -100.0,   34.2, 56.1), Err(Error::OutOfRange));
+    assert_eq!(lpp.add_gps(3,   45.0, -190.0, 56.1), Err(Error::OutOfRange));
+    assert_eq!(lpp.add_gps(3,   45.0,  190.0, 56.1), Err(Error::OutOfRange));
+}
+
+#[test]
 fn add_switch() {
     let mut buffer = [0u8; LPP_SWITCH_SIZE * 2];
     let mut lpp = CayenneLPP::new(&mut buffer);

--- a/tests/tests_api.rs
+++ b/tests/tests_api.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use cayenne_lpp::*;
 use crate::error::Error;
 
@@ -357,4 +359,168 @@ fn test_iter_termination_infailable() {
     // Expect a None now
     assert_eq!(iter.next(), None);
 
+}
+
+#[test]
+fn test_scalar_fmt_debug() {
+    use core::fmt::Write;
+
+    struct StrBuffer(usize, [u8; 128]);
+
+    impl core::fmt::Debug for StrBuffer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_tuple("StrBuffer").field(&self.0).field(&self.1).finish()?;
+            f.write_str(": \"")?;
+            f.write_str(str::from_utf8(&self.1[..]).expect("Illegal string"))?;
+            f.write_str("\"")
+        }
+    }
+
+    impl PartialEq for StrBuffer {
+        fn eq(&self, other: &Self) -> bool {
+           self.0 == other.0 && self.1[..self.0] == other.1[..self.0]
+        }
+    }
+
+    impl Write for StrBuffer {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            let string_slice = s.as_bytes();
+            let new_len = self.0 + string_slice.len();
+            self.1[self.0..new_len].copy_from_slice(string_slice);
+            self.0 = new_len;
+
+            Ok(())
+        }
+    }
+
+    impl Default for StrBuffer {
+        fn default() -> Self {
+            Self(0, [0u8; 128])
+        }
+    }
+
+    impl From<&str> for StrBuffer {
+        fn from(s: &str) -> Self {
+            let string_slice = s.as_bytes();
+            let mut retval = Self::default();
+            retval.0 = string_slice.len();
+            retval.1[..retval.0].copy_from_slice(string_slice);    
+            retval        
+        }
+    }
+
+    // prepare an array that will fit the whole payload
+    let mut buffer = [0u8;
+        LPP_DIGITAL_INPUT_SIZE +
+        LPP_DIGITAL_OUTPUT_SIZE +
+        LPP_ANALOG_INPUT_SIZE +
+        LPP_ANALOG_OUTPUT_SIZE +
+        LPP_GENERIC_SENSOR_SIZE +
+        LPP_LUMINOSITY_SIZE +
+        LPP_PRESENCE_SIZE +
+        LPP_TEMPERATURE_SIZE +
+        LPP_RELATIVE_HUMIDITY_SIZE +
+        LPP_ACCELEROMETER_SIZE +
+        LPP_BAROMETRIC_PRESSURE_SIZE +
+        LPP_VOLTAGE_SIZE +
+        LPP_CURRENT_SIZE +
+        LPP_FREQUENCY_SIZE +
+        LPP_PERCENTAGE_SIZE +
+        LPP_ALTITUDE_SIZE +
+        LPP_CONCENTRATION_SIZE +
+        LPP_POWER_SIZE +
+        LPP_DISTANCE_SIZE +
+        LPP_ENERGY_SIZE +
+        LPP_DIRECTION_SIZE +
+        LPP_UNIXTIME_SIZE +
+        LPP_GYROMETER_SIZE +
+        LPP_CONCENTRATION_SIZE +
+        LPP_COLOR_SIZE +
+        LPP_GPS_SIZE +
+        LPP_SWITCH_SIZE
+    ];
+
+    let mut lpp = CayenneLPP::new(&mut buffer);
+
+    // Make an array of all possible values of a scalar
+    // This will ensure that the code to add a scalar to the
+    // data structure is correct, and it'll also be used to
+    // verify that we can correctly pull them back out via
+    // the iterator;
+    let scalars = [
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::DigitalInput(0x55) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::DigitalOutput(0xAA) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::AnalogInput(12.7) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::AnalogOutput(15.5) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::GenericSensor( 0x1234567) },
+        CayenneLPPScalar{ channel: 9, value: CayenneLPPValue::Luminosity(0x55AA) },
+        CayenneLPPScalar{ channel: 2, value: CayenneLPPValue::Presence(0xAA) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Temperature(25.5) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::RelativeHumidity(65.5) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Accelerometer(6.427, 3.129, -2.853) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::BarometricPressure(992.3) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Voltage(123.45) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Current(12.345) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Frequency(901_525_000) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Percentage(12) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Altitude(-1234) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Concentration(1234) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Power(1234) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Distance(123456789) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Energy(123456789) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Direction(123) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::UnixTime(123456789) },
+        CayenneLPPScalar{ channel: 6, value: CayenneLPPValue::Gyrometer(12.34, 56.78, 9.0) },
+        CayenneLPPScalar{ channel: 4, value: CayenneLPPValue::Color(0x12, 0x34, 0x56) },
+        CayenneLPPScalar{ channel: 1, value: CayenneLPPValue::GPS(42.3518, -87.9094, 10.0) },
+        CayenneLPPScalar{ channel: 3, value: CayenneLPPValue::Switch(true) },
+        CayenneLPPScalar{ channel: 5, value: CayenneLPPValue::Concentration(65000) },
+    ];
+
+    let debugs = [
+        "CayenneLPPScalar { channel: 3, value: DigitalInput(85) }",
+        "CayenneLPPScalar { channel: 5, value: DigitalOutput(170) }",
+        "CayenneLPPScalar { channel: 3, value: AnalogInput(12.7) }",
+        "CayenneLPPScalar { channel: 5, value: AnalogOutput(15.5) }",
+        "CayenneLPPScalar { channel: 3, value: GenericSensor(19088743) }",
+        "CayenneLPPScalar { channel: 9, value: Luminosity (lux) (21930) }",
+        "CayenneLPPScalar { channel: 2, value: Presence(170) }",
+        "CayenneLPPScalar { channel: 5, value: Degrees C(25.5) }",
+        "CayenneLPPScalar { channel: 3, value: RelativeHumidity(65.5) }",
+        "CayenneLPPScalar { channel: 3, value: Accelerometer { X: 6.427, Y: 3.129, Z: -2.853 } }",
+        "CayenneLPPScalar { channel: 5, value: BarometricPressure (hPa) (992.3) }",
+        "CayenneLPPScalar { channel: 3, value: Voltage(123.45) }",
+        "CayenneLPPScalar { channel: 5, value: Current (A) (12.345) }",
+        "CayenneLPPScalar { channel: 3, value: Frequency (hz) (901525000) }",
+        "CayenneLPPScalar { channel: 3, value: Percentage(12) }",
+        "CayenneLPPScalar { channel: 3, value: Altitude (M) (-1234) }",
+        "CayenneLPPScalar { channel: 5, value: Concentration (ppm) (1234) }",
+        "CayenneLPPScalar { channel: 5, value: Power (W) (1234) }",
+        "CayenneLPPScalar { channel: 3, value: Distance (M) (123456789) }",
+        "CayenneLPPScalar { channel: 5, value: Energy (Wh) (123456789) }",
+        "CayenneLPPScalar { channel: 3, value: Direction (deg) (123) }",
+        "CayenneLPPScalar { channel: 5, value: UnixTime(123456789) }",
+        "CayenneLPPScalar { channel: 6, value: Gyrometer { X: 12.34, Y: 56.78, Z: 9.0 } }",
+        "CayenneLPPScalar { channel: 4, value: Color { R: 18, G: 52, B: 86 } }",
+        "CayenneLPPScalar { channel: 1, value: GPS location { Lat: 42.3518, Lon: -87.9094, Alt: 10.0 } }",
+        "CayenneLPPScalar { channel: 3, value: Switch(true) }",
+        "CayenneLPPScalar { channel: 5, value: Concentration (ppm) (65000) }",
+    ];
+
+    for scalar in scalars.into_iter() {
+        lpp.add_scalar(&scalar).unwrap();
+    }
+
+
+    // Now, we should have all the data in the lpp structure;
+    // well iterate through the scalars zip'ed with the sample
+    // data and compare to make sure they match.  This will stop
+    // when one of the iters completes, so we'll keep track of
+    // how many we process.  If it's less than the size of the
+    // example array we know we terminated early.
+    for (example, result) in debugs.into_iter().zip(lpp.into_infailable_iter()) {
+        let mut formatted = StrBuffer::default();
+        write!(&mut formatted, "{:?}", result).expect("failed to format, buffer probably too small");
+        assert_eq!(formatted, <&str as Into<StrBuffer>>::into(example))
+    }
 }


### PR DESCRIPTION
As I've been using the library, I've noticed that it would be nice to have a
iterator that distinguishes between the end of a byte stream and failure
or corruption within the byte stream.   As such, I've made a failable and infailable
version of the iterator that allows you to scan in which ever way you please.